### PR TITLE
feat: add kentaro-m/md2confl

### DIFF
--- a/pkgs/kentaro-m/md2confl/pkg.yaml
+++ b/pkgs/kentaro-m/md2confl/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: kentaro-m/md2confl@v0.4.2

--- a/pkgs/kentaro-m/md2confl/registry.yaml
+++ b/pkgs/kentaro-m/md2confl/registry.yaml
@@ -1,0 +1,23 @@
+packages:
+  - type: github_release
+    repo_owner: kentaro-m
+    repo_name: md2confl
+    asset: md2confl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: md2confl is a CLI tool to convert the markdown text to confluence wiki format
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(.{64})
+        file: "^.{64}\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -7410,6 +7410,28 @@ packages:
     path: has
     description: checks presence of various command line tools and their versions on the path
   - type: github_release
+    repo_owner: kentaro-m
+    repo_name: md2confl
+    asset: md2confl_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    description: md2confl is a CLI tool to convert the markdown text to confluence wiki format
+    replacements:
+      amd64: x86_64
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    checksum:
+      type: github_release
+      asset: checksums.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: ^(.{64})
+        file: "^.{64}\\s+(\\S+)$"
+  - type: github_release
     repo_owner: kevwan
     repo_name: depu
     asset: depu_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[kentaro-m/md2confl](https://github.com/kentaro-m/md2confl): md2confl is a CLI tool to convert the markdown text to confluence wiki format

```console
$ aqua g -i kentaro-m/md2confl
```