### PR TITLE
feat: add cloudfoundry/cli

### DIFF
--- a/pkgs/cloudfoundry/cli/pkg.yaml
+++ b/pkgs/cloudfoundry/cli/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: cloudfoundry/cli@v7.5.0

--- a/pkgs/cloudfoundry/cli/registry.yaml
+++ b/pkgs/cloudfoundry/cli/registry.yaml
@@ -3,7 +3,7 @@ packages:
     repo_owner: cloudfoundry
     repo_name: cli
     description: The official command line client for Cloud Foundry
-    url: https://packages.cloudfoundry.org/stable?release={{.OS}}{{.Arch}}-binary&version={{.trimV .Version}}
+    url: https://packages.cloudfoundry.org/stable?release={{.OS}}{{.Arch}}-binary&version={{trimV .Version}}
     supported_envs:
       - darwin
       - amd64
@@ -13,8 +13,8 @@ packages:
       amd64: x64
     overrides:
       - goos: linux
-        url: https://packages.cloudfoundry.org/stable?release={{.OS}}64-binary&version={{.trimV .Version}}
+        url: https://packages.cloudfoundry.org/stable?release={{.OS}}64-binary&version={{trimV .Version}}
       - goos: windows
-        url: https://packages.cloudfoundry.org/stable?release={{.OS}}64-exe&version={{.trimV .Version}}
+        url: https://packages.cloudfoundry.org/stable?release={{.OS}}64-exe&version={{trimV .Version}}
     files:
       - name: cf

--- a/pkgs/cloudfoundry/cli/registry.yaml
+++ b/pkgs/cloudfoundry/cli/registry.yaml
@@ -1,0 +1,20 @@
+packages:
+  - type: http
+    repo_owner: cloudfoundry
+    repo_name: cli
+    description: The official command line client for Cloud Foundry
+    url: https://packages.cloudfoundry.org/stable?release={{.OS}}{{.Arch}}-binary&version={{.trimV .Version}}
+    supported_envs:
+      - darwin
+      - amd64
+    replacements:
+      darwin: macos
+      arm64: arm
+      amd64: x64
+    overrides:
+      - goos: linux
+        url: https://packages.cloudfoundry.org/stable?release={{.OS}}64-binary&version={{.trimV .Version}}
+      - goos: windows
+        url: https://packages.cloudfoundry.org/stable?release={{.OS}}64-exe&version={{.trimV .Version}}
+    files:
+      - name: cf

--- a/registry.yaml
+++ b/registry.yaml
@@ -3390,6 +3390,25 @@ packages:
     asset: bosh-cli-{{trimV .Version}}-{{.OS}}-{{.Arch}}
     files:
       - name: bosh
+  - type: http
+    repo_owner: cloudfoundry
+    repo_name: cli
+    description: The official command line client for Cloud Foundry
+    url: https://packages.cloudfoundry.org/stable?release={{.OS}}{{.Arch}}-binary&version={{.trimV .Version}}
+    supported_envs:
+      - darwin
+      - amd64
+    replacements:
+      darwin: macos
+      arm64: arm
+      amd64: x64
+    overrides:
+      - goos: linux
+        url: https://packages.cloudfoundry.org/stable?release={{.OS}}64-binary&version={{.trimV .Version}}
+      - goos: windows
+        url: https://packages.cloudfoundry.org/stable?release={{.OS}}64-exe&version={{.trimV .Version}}
+    files:
+      - name: cf
   - type: github_release
     repo_owner: cloudfoundry
     repo_name: credhub-cli

--- a/registry.yaml
+++ b/registry.yaml
@@ -3394,7 +3394,7 @@ packages:
     repo_owner: cloudfoundry
     repo_name: cli
     description: The official command line client for Cloud Foundry
-    url: https://packages.cloudfoundry.org/stable?release={{.OS}}{{.Arch}}-binary&version={{.trimV .Version}}
+    url: https://packages.cloudfoundry.org/stable?release={{.OS}}{{.Arch}}-binary&version={{trimV .Version}}
     supported_envs:
       - darwin
       - amd64
@@ -3404,9 +3404,9 @@ packages:
       amd64: x64
     overrides:
       - goos: linux
-        url: https://packages.cloudfoundry.org/stable?release={{.OS}}64-binary&version={{.trimV .Version}}
+        url: https://packages.cloudfoundry.org/stable?release={{.OS}}64-binary&version={{trimV .Version}}
       - goos: windows
-        url: https://packages.cloudfoundry.org/stable?release={{.OS}}64-exe&version={{.trimV .Version}}
+        url: https://packages.cloudfoundry.org/stable?release={{.OS}}64-exe&version={{trimV .Version}}
     files:
       - name: cf
   - type: github_release


### PR DESCRIPTION
[cloudfoundry/cli](https://github.com/cloudfoundry/cli): The official command line client for Cloud Foundry

```console
$ aqua g -i cloudfoundry/cli
```