### PR TITLE
feat: add pgrok/pgrok

### DIFF
--- a/pkgs/pgrok/pgrok/pgrok/pkg.yaml
+++ b/pkgs/pgrok/pgrok/pgrok/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: pgrok/pgrok@v1.1.1

--- a/pkgs/pgrok/pgrok/pgrok/registry.yaml
+++ b/pkgs/pgrok/pgrok/pgrok/registry.yaml
@@ -1,0 +1,19 @@
+packages:
+  - name: pgrok/pgrok/pgrok
+    type: github_release
+    repo_owner: pgrok
+    repo_name: pgrok
+    description: Poor man's ngrok - a multi-tenant HTTP reverse tunnel solution through SSH remote port forwarding
+    asset: pgrok_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: checksums.pgrok.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/pkgs/pgrok/pgrok/pgrokd/pkg.yaml
+++ b/pkgs/pgrok/pgrok/pgrokd/pkg.yaml
@@ -1,0 +1,2 @@
+packages:
+  - name: pgrok/pgrok@v1.1.1

--- a/pkgs/pgrok/pgrok/pgrokd/registry.yaml
+++ b/pkgs/pgrok/pgrok/pgrokd/registry.yaml
@@ -1,0 +1,21 @@
+packages:
+  - name: pgrok/pgrok/pgrokd
+    type: github_release
+    repo_owner: pgrok
+    repo_name: pgrok
+    description: Poor man's ngrok - a multi-tenant HTTP reverse tunnel solution through SSH remote port forwarding
+    asset: pgrokd_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: pgrokd
+    checksum:
+      type: github_release
+      asset: checksums.pgrokd.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"

--- a/registry.yaml
+++ b/registry.yaml
@@ -17088,6 +17088,44 @@ packages:
       pattern:
         checksum: ^(\b[A-Fa-f0-9]{64}\b)
         file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - name: pgrok/pgrok/pgrok
+    type: github_release
+    repo_owner: pgrok
+    repo_name: pgrok
+    description: Poor man's ngrok - a multi-tenant HTTP reverse tunnel solution through SSH remote port forwarding
+    asset: pgrok_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    checksum:
+      type: github_release
+      asset: checksums.pgrok.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
+  - name: pgrok/pgrok/pgrokd
+    type: github_release
+    repo_owner: pgrok
+    repo_name: pgrok
+    description: Poor man's ngrok - a multi-tenant HTTP reverse tunnel solution through SSH remote port forwarding
+    asset: pgrokd_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    files:
+      - name: pgrokd
+    checksum:
+      type: github_release
+      asset: checksums.pgrokd.txt
+      file_format: regexp
+      algorithm: sha256
+      pattern:
+        checksum: "^(\\b[A-Fa-f0-9]{64}\\b)"
+        file: "^\\b[A-Fa-f0-9]{64}\\b\\s+(\\S+)$"
   - type: github_release
     repo_owner: phiresky
     repo_name: ripgrep-all


### PR DESCRIPTION
[pgrok/pgrok/pgrok](https://github.com/pgrok/pgrok): Poor man's ngrok - a multi-tenant HTTP reverse tunnel solution through SSH remote port forwarding

```console
$ aqua g -i pgrok/pgrok/pgrok
$ aqua g -i pgrok/pgrok/pgrokd
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

This tool contains are `pgrok` (client) and `pgrokd` (server).

```console
$ pgrok --help
NAME:
   pgrok - Poor man's ngrok

USAGE:
   pgrok [global options] command [command options] [arguments...]

VERSION:
   1.1.1

COMMANDS:
   http
   init
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --config value, -c value  The path to the config file (default: "/Users/yuya-koda/.pgrok/pgrok.yml")
   --debug, -d               Whether to enable debug mode (default: false)
   --help, -h                show help
   --version, -v             print the version
```

```console
$ pgrokd --help
Usage of /Users/user/.local/share/aquaproj-aqua/pkgs/github_release/github.com/pgrok/pgrok/v1.1.1/pgrokd_1.1.1_darwin_amd64.tar.gz/pgrokd:
  -config string
        the path to the config file (default "pgrokd.yml")
```

Reference

- README (pgrokd)
	- https://github.com/pgrok/pgrok#set-up-the-server-pgrokd
- README (pgrok)
	- https://github.com/pgrok/pgrok#set-up-the-client-pgrok
