### PR TITLE
feat: add sass/dart-sass

### DIFF
--- a/pkgs/alexellis/arkade/pkg.yaml
+++ b/pkgs/alexellis/arkade/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: alexellis/arkade@0.9.27
+  - name: alexellis/arkade@0.10.0

--- a/pkgs/che-incubator/chectl/pkg.yaml
+++ b/pkgs/che-incubator/chectl/pkg.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: che-incubator/chectl@20230829133348
+  - name: che-incubator/chectl@20230829143951

--- a/pkgs/sass/dart-sass/pkg.yaml
+++ b/pkgs/sass/dart-sass/pkg.yaml
@@ -1,0 +1,44 @@
+packages:
+  - name: sass/dart-sass@1.66.1
+  - name: sass/dart-sass
+    version: 1.66.0
+  - name: sass/dart-sass
+    version: 1.65.0
+  - name: sass/dart-sass
+    version: 1.63.1
+  - name: sass/dart-sass
+    version: 1.63.0
+  - name: sass/dart-sass
+    version: 1.59.1
+  - name: sass/dart-sass
+    version: 1.59.0
+  - name: sass/dart-sass
+    version: 1.56.1
+  - name: sass/dart-sass
+    version: 1.56.0
+  - name: sass/dart-sass
+    version: 1.49.11
+  - name: sass/dart-sass
+    version: 1.49.10
+  - name: sass/dart-sass
+    version: 1.26.7
+  - name: sass/dart-sass
+    version: 1.26.5
+  - name: sass/dart-sass
+    version: 1.26.0
+  - name: sass/dart-sass
+    version: 1.26.0-test.1
+  - name: sass/dart-sass
+    version: 1.24.2
+  - name: sass/dart-sass
+    version: 1.24.1
+  - name: sass/dart-sass
+    version: 1.23.7
+  - name: sass/dart-sass
+    version: 1.23.6
+  - name: sass/dart-sass
+    version: 1.20.1
+  - name: sass/dart-sass
+    version: 1.20.0
+  - name: sass/dart-sass
+    version: 1.0.0-alpha.1

--- a/pkgs/sass/dart-sass/registry.yaml
+++ b/pkgs/sass/dart-sass/registry.yaml
@@ -1,0 +1,122 @@
+packages:
+  - type: github_release
+    repo_owner: sass
+    repo_name: dart-sass
+    description: The reference implementation of Sass, written in Dart
+    asset: dart-sass-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x64
+      darwin: macos
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: sass
+        src: dart-sass/sass
+    version_constraint: semver(">= 1.66.0")
+    version_overrides:
+      - version_constraint: semver(">= 1.65.0")
+        rosetta2: true
+      - version_constraint: semver(">= 1.63.1")
+      - version_constraint: semver(">= 1.63.0")
+        rosetta2: true
+      - version_constraint: semver(">= 1.59.1")
+      - version_constraint: semver(">= 1.59.0")
+        overrides: []
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux
+      - version_constraint: semver(">= 1.56.1")
+      - version_constraint: semver(">= 1.56.0")
+        rosetta2: true
+      - version_constraint: semver(">= 1.49.11")
+      - version_constraint: semver(">= 1.49.10")
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver(">= 1.49.10")
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver(">= 1.26.7")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 1.26.5")
+        overrides: []
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver(">= 1.26.0")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 1.26.0-test.1")
+        overrides: []
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver(">= 1.24.2")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 1.24.1")
+        overrides: []
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver(">= 1.23.7")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 1.23.6")
+        overrides: []
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver(">= 1.20.1")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 1.20.0")
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver(">= 1.20.0")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: "true"
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        files:
+          - name: sass
+            src: dart-sass/dart-sass

--- a/pkgs/sass/dart-sass/registry.yaml
+++ b/pkgs/sass/dart-sass/registry.yaml
@@ -14,7 +14,6 @@ packages:
     supported_envs:
       - darwin
       - linux
-      - amd64
     files:
       - name: sass
         src: dart-sass/sass
@@ -41,7 +40,6 @@ packages:
           amd64: x64
         supported_envs:
           - linux/amd64
-          - windows/amd64
       - version_constraint: semver(">= 1.49.10")
         format: zip
         overrides:
@@ -51,11 +49,10 @@ packages:
           amd64: x64
         supported_envs:
           - linux/amd64
-          - windows/amd64
       - version_constraint: semver(">= 1.26.7")
         supported_envs:
           - darwin
-          - amd64
+          - linux/amd64
         rosetta2: true
       - version_constraint: semver(">= 1.26.5")
         overrides: []
@@ -66,7 +63,7 @@ packages:
       - version_constraint: semver(">= 1.26.0")
         supported_envs:
           - darwin
-          - amd64
+          - linux/amd64
         rosetta2: true
       - version_constraint: semver(">= 1.26.0-test.1")
         overrides: []
@@ -77,7 +74,7 @@ packages:
       - version_constraint: semver(">= 1.24.2")
         supported_envs:
           - darwin
-          - amd64
+          - linux/amd64
         rosetta2: true
       - version_constraint: semver(">= 1.24.1")
         overrides: []
@@ -88,7 +85,7 @@ packages:
       - version_constraint: semver(">= 1.23.7")
         supported_envs:
           - darwin
-          - amd64
+          - linux/amd64
         rosetta2: true
       - version_constraint: semver(">= 1.23.6")
         overrides: []
@@ -99,23 +96,22 @@ packages:
       - version_constraint: semver(">= 1.20.1")
         supported_envs:
           - darwin
-          - amd64
+          - linux/amd64
         rosetta2: true
       - version_constraint: semver(">= 1.20.0")
         replacements:
           amd64: x64
         supported_envs:
           - linux/amd64
-          - windows/amd64
       - version_constraint: semver(">= 1.20.0")
         supported_envs:
           - darwin
-          - amd64
+          - linux/amd64
         rosetta2: true
       - version_constraint: "true"
         supported_envs:
           - darwin
-          - amd64
+          - linux/amd64
         rosetta2: true
         files:
           - name: sass

--- a/registry.yaml
+++ b/registry.yaml
@@ -21205,6 +21205,127 @@ packages:
     repo_name: gomockhandler
     description: Mr. gomockhandler is the clever and more agile manager of golang/mock
   - type: github_release
+    repo_owner: sass
+    repo_name: dart-sass
+    description: The reference implementation of Sass, written in Dart
+    asset: dart-sass-{{.Version}}-{{.OS}}-{{.Arch}}.{{.Format}}
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x64
+      darwin: macos
+    supported_envs:
+      - darwin
+      - linux
+      - amd64
+    files:
+      - name: sass
+        src: dart-sass/sass
+    version_constraint: semver(">= 1.66.0")
+    version_overrides:
+      - version_constraint: semver(">= 1.65.0")
+        rosetta2: true
+      - version_constraint: semver(">= 1.63.1")
+      - version_constraint: semver(">= 1.63.0")
+        rosetta2: true
+      - version_constraint: semver(">= 1.59.1")
+      - version_constraint: semver(">= 1.59.0")
+        overrides: []
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux
+      - version_constraint: semver(">= 1.56.1")
+      - version_constraint: semver(">= 1.56.0")
+        rosetta2: true
+      - version_constraint: semver(">= 1.49.11")
+      - version_constraint: semver(">= 1.49.10")
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver(">= 1.49.10")
+        format: zip
+        overrides:
+          - goos: linux
+            format: tar.gz
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver(">= 1.26.7")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 1.26.5")
+        overrides: []
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver(">= 1.26.0")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 1.26.0-test.1")
+        overrides: []
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver(">= 1.24.2")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 1.24.1")
+        overrides: []
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+      - version_constraint: semver(">= 1.23.7")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 1.23.6")
+        overrides: []
+        supported_envs:
+          - linux/amd64
+          - darwin
+        rosetta2: true
+      - version_constraint: semver(">= 1.20.1")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: semver(">= 1.20.0")
+        replacements:
+          amd64: x64
+        supported_envs:
+          - linux/amd64
+          - windows/amd64
+      - version_constraint: semver(">= 1.20.0")
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+      - version_constraint: "true"
+        supported_envs:
+          - darwin
+          - amd64
+        rosetta2: true
+        files:
+          - name: sass
+            src: dart-sass/dart-sass
+  - type: github_release
     repo_owner: sassman
     repo_name: t-rec-rs
     description: Blazingly fast terminal recorder that generates animated gif images for the web written in rust

--- a/registry.yaml
+++ b/registry.yaml
@@ -21219,7 +21219,6 @@ packages:
     supported_envs:
       - darwin
       - linux
-      - amd64
     files:
       - name: sass
         src: dart-sass/sass
@@ -21246,7 +21245,6 @@ packages:
           amd64: x64
         supported_envs:
           - linux/amd64
-          - windows/amd64
       - version_constraint: semver(">= 1.49.10")
         format: zip
         overrides:
@@ -21256,11 +21254,10 @@ packages:
           amd64: x64
         supported_envs:
           - linux/amd64
-          - windows/amd64
       - version_constraint: semver(">= 1.26.7")
         supported_envs:
           - darwin
-          - amd64
+          - linux/amd64
         rosetta2: true
       - version_constraint: semver(">= 1.26.5")
         overrides: []
@@ -21271,7 +21268,7 @@ packages:
       - version_constraint: semver(">= 1.26.0")
         supported_envs:
           - darwin
-          - amd64
+          - linux/amd64
         rosetta2: true
       - version_constraint: semver(">= 1.26.0-test.1")
         overrides: []
@@ -21282,7 +21279,7 @@ packages:
       - version_constraint: semver(">= 1.24.2")
         supported_envs:
           - darwin
-          - amd64
+          - linux/amd64
         rosetta2: true
       - version_constraint: semver(">= 1.24.1")
         overrides: []
@@ -21293,7 +21290,7 @@ packages:
       - version_constraint: semver(">= 1.23.7")
         supported_envs:
           - darwin
-          - amd64
+          - linux/amd64
         rosetta2: true
       - version_constraint: semver(">= 1.23.6")
         overrides: []
@@ -21304,23 +21301,22 @@ packages:
       - version_constraint: semver(">= 1.20.1")
         supported_envs:
           - darwin
-          - amd64
+          - linux/amd64
         rosetta2: true
       - version_constraint: semver(">= 1.20.0")
         replacements:
           amd64: x64
         supported_envs:
           - linux/amd64
-          - windows/amd64
       - version_constraint: semver(">= 1.20.0")
         supported_envs:
           - darwin
-          - amd64
+          - linux/amd64
         rosetta2: true
       - version_constraint: "true"
         supported_envs:
           - darwin
-          - amd64
+          - linux/amd64
         rosetta2: true
         files:
           - name: sass


### PR DESCRIPTION
[sass/dart-sass](https://github.com/sass/dart-sass): The reference implementation of Sass, written in Dart

```console
$ aqua g -i sass/dart-sass
```

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
$ sass --help
Compile Sass to CSS.

Usage: sass <input.scss> [output.css]
       sass <input.scss>:<output.css> <input/>:<output/> <dir/>

━━━ Input and Output ━━━━━━━━━━━━━━━━━━━
    --[no-]stdin                   Read the stylesheet from stdin.
    --[no-]indented                Use the indented syntax for input from stdin.
-I, --load-path=<PATH>             A path to use when resolving imports.
                                   May be passed multiple times.
-s, --style=<NAME>                 Output style.
                                   [expanded (default), compressed]
    --[no-]charset                 Emit a @charset or BOM for CSS with non-ASCII characters.
                                   (defaults to on)
    --[no-]error-css               When an error occurs, emit a stylesheet describing it.
                                   Defaults to true when compiling to a file.
    --update                       Only compile out-of-date stylesheets.

━━━ Source Maps ━━━━━━━━━━━━━━━━━━━━━━━━
    --[no-]source-map              Whether to generate source maps.
                                   (defaults to on)
    --source-map-urls              How to link from source maps to source files.
                                   [relative (default), absolute]
    --[no-]embed-sources           Embed source file contents in source maps.
    --[no-]embed-source-map        Embed source map contents in CSS.

━━━ Warnings ━━━━━━━━━━━━━━━━━━━━━━━━━━━
-q, --[no-]quiet                   Don't print warnings.
    --[no-]quiet-deps              Don't print compiler warnings from dependencies.
                                   Stylesheets imported through load paths count as dependencies.
    --[no-]verbose                 Print all deprecation warnings even when they're repetitive.
    --fatal-deprecation            Deprecations to treat as errors. You may also pass a Sass
                                   version to include any behavior deprecated in or before it.
                                   See https://sass-lang.com/documentation/breaking-changes for
                                   a complete list.

          [abs-percent]            Passing percentages to the Sass abs() function.
          [bogus-combinators]      Leading, trailing, and repeated combinators.
          [call-string]            Passing a string directly to meta.call().
          [color-module-compat]    Using color module functions in place of plain CSS functions.
          [duplicate-var-flags]    Using !default or !global multiple times for one variable.
          [elseif]                 @elseif.
          [function-units]         Passing invalid units to built-in functions.
          [moz-document]           @-moz-document.
          [new-global]             Declaring new variables with !global.
          [null-alpha]             Passing null as alpha in the Dart API.
          [slash-div]              / operator for division.
          [strict-unary]           Ambiguous + and - operators.

    --future-deprecation           Opt in to a deprecation early.

          [import]                 @import rules.

━━━ Other ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-w, --watch                        Watch stylesheets and recompile when they change.
    --[no-]poll                    Manually check for changes rather than using a native watcher.
                                   Only valid with --watch.
    --[no-]stop-on-error           Don't compile more files once an error is encountered.
-i, --interactive                  Run an interactive SassScript shell.
-c, --[no-]color                   Whether to use terminal colors for messages.
    --[no-]unicode                 Whether to use Unicode characters for messages.
    --[no-]trace                   Print full Dart stack traces for exceptions.
-h, --help                         Print this usage information.
    --version                      Print the version of Dart Sass.
```

Reference

- Install guide
    - https://sass-lang.com/install/

> You can install Sass on Windows, Mac, or Linux by downloading the package for your operating system [from GitHub](https://github.com/sass/dart-sass/releases/tag/1.57.1) and [adding it to your PATH](https://katiek2.github.io/path-doc/). That’s all—there are no external dependencies and nothing else you need to install.
