### PR TITLE
feat: add bflad/tfproviderlint

### DIFF
--- a/pkgs/bflad/tfproviderlint/pkg.yaml
+++ b/pkgs/bflad/tfproviderlint/pkg.yaml
@@ -1,0 +1,4 @@
+packages:
+  - name: bflad/tfproviderlint@v0.29.0
+  - name: bflad/tfproviderlint
+    version: v0.28.1

--- a/pkgs/bflad/tfproviderlint/registry.yaml
+++ b/pkgs/bflad/tfproviderlint/registry.yaml
@@ -1,0 +1,33 @@
+packages:
+  - type: github_release
+    repo_owner: bflad
+    repo_name: tfproviderlint
+    description: Terraform Provider Lint Tool
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.28.1")
+        asset: tfproviderlint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: tfproviderlint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: tfproviderlint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: tfproviderlint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip

--- a/registry.yaml
+++ b/registry.yaml
@@ -8594,6 +8594,38 @@ packages:
           - amd64
         rosetta2: true
   - type: github_release
+    repo_owner: bflad
+    repo_name: tfproviderlint
+    description: Terraform Provider Lint Tool
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.28.1")
+        asset: tfproviderlint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        windows_arm_emulation: true
+        checksum:
+          type: github_release
+          asset: tfproviderlint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: "true"
+        asset: tfproviderlint_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        checksum:
+          type: github_release
+          asset: tfproviderlint_{{trimV .Version}}_checksums.txt
+          algorithm: sha256
+        overrides:
+          - goos: windows
+            format: zip
+  - type: github_release
     repo_owner: binwiederhier
     repo_name: ntfy
     description: Send push notifications to your phone or desktop using PUT/POST


### PR DESCRIPTION
[bflad/tfproviderlint](https://github.com/bflad/tfproviderlint): Terraform Provider Lint Tool

```console
$ aqua g -i bflad/tfproviderlint
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@9a95644895f0:/workspace# tfproviderlint --help
Usage of tfproviderlint:
  -AT001
        enable AT001 analysis
  -AT001.ignored-filename-prefixes string
        Comma-separated list of file name prefixes to ignore (default "data_source_")
  -AT001.ignored-filename-suffixes string
        Comma-separated list of file name suffixes to ignore
  -AT002
        enable AT002 analysis
  -AT003
        enable AT003 analysis
  -AT004
        enable AT004 analysis
  -AT005
        enable AT005 analysis
  -AT006
        enable AT006 analysis
  -AT007
        enable AT007 analysis
  -AT008
        enable AT008 analysis
  -AT009
        enable AT009 analysis
  -AT010
        enable AT010 analysis
  -AT011
        enable AT011 analysis
  -AT012
        enable AT012 analysis
  -AT012.ignored-filenames string
        Comma-separated list of file names to ignore
  -R001
        enable R001 analysis
  -R002
        enable R002 analysis
  -R003
        enable R003 analysis
  -R004
        enable R004 analysis
  -R005
        enable R005 analysis
  -R006
        enable R006 analysis
  -R006.package-aliases string
        Comma-separated list of additional Go import paths to consider as aliases for helper/resource
  -R007
        enable R007 analysis
  -R008
        enable R008 analysis
  -R009
        enable R009 analysis
  -R010
        enable R010 analysis
  -R011
        enable R011 analysis
  -R012
        enable R012 analysis
  -R013
        enable R013 analysis
  -R014
        enable R014 analysis
  -R015
        enable R015 analysis
  -R016
        enable R016 analysis
  -R017
        enable R017 analysis
  -R018
        enable R018 analysis
  -R019
        enable R019 analysis
  -R019.threshold int
        Number of arguments for reporting (default 5)
  -S001
        enable S001 analysis
  -S002
        enable S002 analysis
  -S003
        enable S003 analysis
  -S004
        enable S004 analysis
  -S005
        enable S005 analysis
  -S006
        enable S006 analysis
  -S007
        enable S007 analysis
  -S008
        enable S008 analysis
  -S009
        enable S009 analysis
  -S010
        enable S010 analysis
  -S011
        enable S011 analysis
  -S012
        enable S012 analysis
  -S013
        enable S013 analysis
  -S014
        enable S014 analysis
  -S015
        enable S015 analysis
  -S016
        enable S016 analysis
  -S017
        enable S017 analysis
  -S018
        enable S018 analysis
  -S019
        enable S019 analysis
  -S020
        enable S020 analysis
  -S021
        enable S021 analysis
  -S022
        enable S022 analysis
  -S023
        enable S023 analysis
  -S024
        enable S024 analysis
  -S025
        enable S025 analysis
  -S026
        enable S026 analysis
  -S027
        enable S027 analysis
  -S028
        enable S028 analysis
  -S029
        enable S029 analysis
  -S030
        enable S030 analysis
  -S031
        enable S031 analysis
  -S032
        enable S032 analysis
  -S033
        enable S033 analysis
  -S034
        enable S034 analysis
  -S035
        enable S035 analysis
  -S036
        enable S036 analysis
  -S037
        enable S037 analysis
  -V    print version and exit
  -V001
        enable V001 analysis
  -V002
        enable V002 analysis
  -V003
        enable V003 analysis
  -V004
        enable V004 analysis
  -V005
        enable V005 analysis
  -V006
        enable V006 analysis
  -V007
        enable V007 analysis
  -V008
        enable V008 analysis
  -V009
        enable V009 analysis
  -V010
        enable V010 analysis
  -V011
        enable V011 analysis
  -V012
        enable V012 analysis
  -V013
        enable V013 analysis
  -V014
        enable V014 analysis
  -all
        no effect (deprecated)
  -c int
        display offending line with this many lines of context (default -1)
  -cpuprofile string
        write CPU profile to this file
  -debug string
        debug flags, any subset of "fpstv"
  -fix
        apply all suggested fixes
  -flags
        print analyzer flags in JSON
  -json
        emit JSON output
  -memprofile string
        write memory profile to this file
  -source
        no effect (deprecated)
  -tags string
        no effect (deprecated)
  -test
        indicates whether test files should be analyzed, too (default true)
  -trace string
        write trace log to this file
  -v    no effect (deprecated)
  -version
        print version and exit
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/bflad/tfproviderlint/blob/main/README.md
