### PR TITLE
feat: add dag-andersen/argocd-diff-preview

### DIFF
--- a/pkgs/dag-andersen/argocd-diff-preview/pkg.yaml
+++ b/pkgs/dag-andersen/argocd-diff-preview/pkg.yaml
@@ -1,0 +1,6 @@
+packages:
+  - name: dag-andersen/argocd-diff-preview@v0.0.10
+  - name: dag-andersen/argocd-diff-preview
+    version: v0.0.6
+  - name: dag-andersen/argocd-diff-preview
+    version: v0.0.5

--- a/pkgs/dag-andersen/argocd-diff-preview/registry.yaml
+++ b/pkgs/dag-andersen/argocd-diff-preview/registry.yaml
@@ -2,6 +2,7 @@ packages:
   - type: github_release
     repo_owner: dag-andersen
     repo_name: argocd-diff-preview
+    description: Argo CD Diff Preview is a tool that renders the diff between two branches in a Git repository
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.5")

--- a/pkgs/dag-andersen/argocd-diff-preview/registry.yaml
+++ b/pkgs/dag-andersen/argocd-diff-preview/registry.yaml
@@ -1,0 +1,51 @@
+packages:
+  - type: github_release
+    repo_owner: dag-andersen
+    repo_name: argocd-diff-preview
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.5")
+        asset: argocd-diff-preview-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: Darwin
+          linux: Linux
+        overrides:
+          - goos: darwin
+            asset: argocd-diff-preview-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v0.0.6"
+        asset: argocd-diff-preview-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: darwin
+            asset: argocd-diff-preview-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: argocd-diff-preview-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: Darwin
+          linux: Linux
+        overrides:
+          - goos: darwin
+            asset: argocd-diff-preview-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin

--- a/registry.yaml
+++ b/registry.yaml
@@ -14585,6 +14585,56 @@ packages:
     checksum:
       enabled: false
   - type: github_release
+    repo_owner: dag-andersen
+    repo_name: argocd-diff-preview
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.0.5")
+        asset: argocd-diff-preview-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: Darwin
+          linux: Linux
+        overrides:
+          - goos: darwin
+            asset: argocd-diff-preview-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: Version == "v0.0.6"
+        asset: argocd-diff-preview-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+        format: tar.gz
+        rosetta2: true
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+        overrides:
+          - goos: linux
+            replacements:
+              arm64: aarch64
+          - goos: darwin
+            asset: argocd-diff-preview-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+      - version_constraint: "true"
+        asset: argocd-diff-preview-{{.OS}}-{{.Arch}}-musl.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          arm64: aarch64
+          darwin: Darwin
+          linux: Linux
+        overrides:
+          - goos: darwin
+            asset: argocd-diff-preview-{{.OS}}-{{.Arch}}.{{.Format}}
+        supported_envs:
+          - linux
+          - darwin
+  - type: github_release
     repo_owner: dagger
     repo_name: dagger
     description: A portable devkit for CI/CD pipelines

--- a/registry.yaml
+++ b/registry.yaml
@@ -14587,6 +14587,7 @@ packages:
   - type: github_release
     repo_owner: dag-andersen
     repo_name: argocd-diff-preview
+    description: Argo CD Diff Preview is a tool that renders the diff between two branches in a Git repository
     version_constraint: "false"
     version_overrides:
       - version_constraint: semver("<= 0.0.5")


### PR DESCRIPTION
[dag-andersen/argocd-diff-preview](https://github.com/dag-andersen/argocd-diff-preview): Argo CD Diff Preview is a tool that renders the diff between two branches in a Git repository

```console
$ aqua g -i dag-andersen/argocd-diff-preview
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request
- [x] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [x] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@5cdc8fe7d826:/workspace# argocd-diff-preview --help                                                                                                                                                                                                          
argocd-diff-preview 0.0.10
A tool that generates the diff between two branches

USAGE:
    argocd-diff-preview [FLAGS] [OPTIONS] --repo <repo> --target-branch <target-branch>

FLAGS:
    -d, --debug      Activate debug mode
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --argocd-version <argocd-version>                      Argo CD version. Default: stable [env: ARGOCD_VERSION=]
    -b, --base-branch <base-branch>                            Base branch name [env: BASE_BRANCH=]  [default: main]
    -i, --diff-ignore <diff-ignore>
            Ignore lines in diff. Example: use 'v[1,9]+.[1,9]+.[1,9]+' for ignoring changes caused by version changes
            following semver [env: DIFF_IGNORE=]
    -r, --file-regex <file-regex>
            Regex to filter files. Example: "/apps_.*\.yaml" [env: FILE_REGEX=]

        --kustomize-build-options <kustomize-build-options>     [env: KUSTOMIZE_BUILD_OPTIONS=]
    -l, --line-count <line-count>
            Generate diffs with <n> lines above and below the highlighted changes in the diff. Default: 10 [env:
            LINE_COUNT=]
        --local-cluster-tool <local-cluster-tool>
            Local cluster tool. Options: kind, minikube, auto. Default: Auto [env: LOCAL_CLUSTER_TOOL=]

        --max-diff-length <max-diff-length>
            Max diff message character count. Default: 65536 (GitHub comment limit) [env: MAX_DIFF_LENGTH=]

    -o, --output-folder <output-folder>
            Output folder where the diff will be saved [env: OUTPUT_FOLDER=]  [default: ./output]

        --repo <repo>                                          Git Repository. Format: OWNER/REPO [env: REPO=]
    -s, --secrets-folder <secrets-folder>
            Secrets folder where the secrets are read from [env: SECRETS_FOLDER=]  [default: ./secrets]

    -t, --target-branch <target-branch>                        Target branch name [env: TARGET_BRANCH=]
        --timeout <timeout>                                    Set timeout [env: TIMEOUT=]  [default: 180]
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/dag-andersen/argocd-diff-preview/blob/main/README.md
