### PR TITLE
feat: add omissis/go-jsonschema

### DIFF
--- a/pkgs/omissis/go-jsonschema/pkg.yaml
+++ b/pkgs/omissis/go-jsonschema/pkg.yaml
@@ -1,0 +1,10 @@
+packages:
+  - name: omissis/go-jsonschema@v0.17.0
+  - name: omissis/go-jsonschema
+    version: v0.13.1
+  - name: omissis/go-jsonschema
+    version: v0.13.0
+  - name: omissis/go-jsonschema
+    version: v0.12.0
+  - name: omissis/go-jsonschema
+    version: v0.9.0

--- a/pkgs/omissis/go-jsonschema/registry.yaml
+++ b/pkgs/omissis/go-jsonschema/registry.yaml
@@ -1,0 +1,69 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/registry.json
+packages:
+  - type: github_release
+    repo_owner: omissis
+    repo_name: go-jsonschema
+    description: A tool to generate Go data types from JSON Schema definitions
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.9.0")
+        asset: gojsonschema-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.12.0")
+        asset: go-jsonschema_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.13.0")
+        asset: go-jsonschema_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v0.13.1-rc.0"
+        no_asset: true
+      - version_constraint: Version == "v0.13.1"
+        asset: go-jsonschema_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v0.14.0-rc.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: go-jsonschema_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256

--- a/registry.yaml
+++ b/registry.yaml
@@ -41642,6 +41642,73 @@ packages:
         supported_envs:
           - linux/arm64
   - type: github_release
+    repo_owner: omissis
+    repo_name: go-jsonschema
+    description: A tool to generate Go data types from JSON Schema definitions
+    version_constraint: "false"
+    version_overrides:
+      - version_constraint: semver("<= 0.9.0")
+        asset: gojsonschema-{{.OS}}-{{.Arch}}
+        format: raw
+        rosetta2: true
+        windows_arm_emulation: true
+        supported_envs:
+          - darwin
+          - windows
+          - amd64
+      - version_constraint: semver("<= 0.12.0")
+        asset: go-jsonschema_{{trimV .Version}}_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: semver("<= 0.13.0")
+        asset: go-jsonschema_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v0.13.1-rc.0"
+        no_asset: true
+      - version_constraint: Version == "v0.13.1"
+        asset: go-jsonschema_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+      - version_constraint: Version == "v0.14.0-rc.0"
+        no_asset: true
+      - version_constraint: "true"
+        asset: go-jsonschema_{{.OS}}_{{.Arch}}.{{.Format}}
+        format: tar.gz
+        replacements:
+          amd64: x86_64
+          darwin: Darwin
+          linux: Linux
+          windows: Windows
+        checksum:
+          type: github_release
+          asset: checksums.txt
+          algorithm: sha256
+  - type: github_release
     repo_owner: omrikiei
     repo_name: ktunnel
     asset: ktunnel_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz


### PR DESCRIPTION
[omissis/go-jsonschema](https://github.com/omissis/go-jsonschema): A tool to generate Go data types from JSON Schema definitions

```console
$ aqua g -i omissis/go-jsonschema
```

## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [ ] Read [CONTRIBUTING.md](https://aquaproj.github.io/docs/products/aqua-registry/contributing)
  - [ ] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
- [ ] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
  - This repository enables `Require signed commits`, so all commits must be signed
- [ ] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [ ] Do only one thing in one Pull Request
- [ ] [Execute cmdx s to scaffold code](https://aquaproj.github.io/docs/products/aqua-registry/contributing/#use-cmdx-s-definitely)
- [ ] Install and execute the package and confirm if the package works well

## How to confirm if this package works well

Reviewers aren't necessarily familiar with this package, so please describe how to confirm if this package works well.
Please confirm if this package works well yourself as much as possible.

Command and output

```console
root@65781a3f22e7:/workspace# go-jsonschema --help
Generates Go code from JSON Schema files.

Usage:
  go-jsonschema FILE ... [flags]

Flags:
      --capitalization strings      Specify a preferred Go capitalization for a string. For example, by default a field
                                    named 'id' becomes 'Id'. With --capitalization ID, it will be generated as 'ID'.
  -e, --extra-imports               Allow extra imports (non standard library)
  -h, --help                        help for go-jsonschema
      --min-sized-ints              Uses sized int and uint values based on the min and max values for the field
      --only-models                 Generate only models (no unmarshal methods, no validation)
  -o, --output string               File to write (- for standard output) (default "-")
  -p, --package string              Default name of package to declare Go files under, unless overridden with
                                    --schema-package
      --resolve-extension strings   Add a file extension that is used to resolve schema names, e.g. {"$ref": "./foo"} will
                                    also look for foo.json if --resolve-extension json is provided.
      --schema-output strings       File to write (- for standard output) a specific schema ID to;
                                    must be in the format URI=FILENAME.
      --schema-package strings      Name of package to declare Go files for a specific schema ID under;
                                    must be in the format URI=PACKAGE.
      --schema-root-type strings    Override name to use for the root type of a specific schema ID;
                                    must be in the format URI=TYPE. By default, it is derived from the file name.
  -t, --struct-name-from-title      Use the schema title as the generated struct name
      --tags strings                Specify which struct tags to generate. Defaults are json, yaml, mapstructure (default [json,yaml,mapstructure])
  -v, --verbose                     Verbose output
      --yaml-extension strings      Add a file extension that should be recognized as YAML. Default are .yml, .yaml. (default [.yml,.yaml])
```

If files such as configuration file are needed, please share them.

Reference

- https://github.com/omissis/go-jsonschema/blob/main/README.md
